### PR TITLE
View mode - for viewing HTML output of requests

### DIFF
--- a/external_request_mock/view.html
+++ b/external_request_mock/view.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    </head>
+    <body>
+    <h2>View HTML output of application.</h2>
+    <p>This application posts a request through to the application server. If you're running the application from the included vagrant box, this will work as is. Otherwise, you'll need to tweak the href and action settings to point correctly.</p>
+        <form method="POST" action="http://192.168.33.101:9999/view">
+            <textarea name="data" id="data" style="width:80%;height:500px;margin: 0 10%;"></textarea>
+            <input type="submit" name="submit" id="submit" style="margin:0 10%;" value="Submit" />
+        </form>
+    </body>
+</html>

--- a/pdf_server.py
+++ b/pdf_server.py
@@ -50,7 +50,7 @@ def download():
     return response
 
 # view route - returns report directly to calling page as html
-@app.route("/view")
+@app.route("/view", methods = ["GET", "POST"])
 def view():
     return renderRequest(request)
 

--- a/templates/town_profile.html
+++ b/templates/town_profile.html
@@ -310,6 +310,5 @@ Town Profile{% if config["town"] -%} - {{ config["town"] }}{% endif -%}
     </div>
     <div class="anchor"></div>
 </div>
-<a href="/town_profile?print=1" target="_blank" class="noprint">Print View</a>
 {% endblock body %}
  


### PR DESCRIPTION
the view endpoint in main application is now available for use and debugging.

navigating to the external mock URL, and going to the page `/view.html` will present you with the same form as the pdf mock request. Upon submission this form is POST-ed to the main pdf server URL view endpoint, and you are presented with the html output from that request.
